### PR TITLE
Add page-independent margins and padding.

### DIFF
--- a/src/popup.css
+++ b/src/popup.css
@@ -12,3 +12,9 @@
   border: solid rgb(10, 168, 253);
   border-radius: 5px;
 }
+
+.cc-box p {
+  color: black;
+  margin: 0;
+  padding: 0;
+}


### PR DESCRIPTION
The extension's style was broken due to page-specific CSS.
<img width="768" alt="スクリーンショット 2022-07-12 15 02 51" src="https://user-images.githubusercontent.com/51479912/178419838-e14e7315-709a-4a5f-a540-8578bb53d20b.png">
<img width="760" alt="スクリーンショット 2022-07-12 15 03 02" src="https://user-images.githubusercontent.com/51479912/178419858-bd35b5a2-4cc1-4352-a7d3-4529b0dc1cf2.png">

