### PR TITLE
Feat ignore symbols for words

### DIFF
--- a/src/count.js
+++ b/src/count.js
@@ -8,7 +8,7 @@ function calculateCharacterCount(string) {
 
   const characters = segmentsGrapheme.filter(char => !isNewLine(char.segment))
   const spaces = characters.filter(char => isSpace(char.segment))
-  const words = segmentsWord.filter(word => !isSpace(word.segment) && !isNewLine(word.segment))
+  const words = segmentsWord.filter(word => !isSpace(word.segment) && !isNewLine(word.segment) && !isSymbol(word.segment))
 
   return [characters.length, spaces.length, words.length]
 }
@@ -19,4 +19,11 @@ function isSpace(char) {
 
 function isNewLine(char) {
   return char === "\n" ? true : false
+}
+
+function isSymbol(char) {
+  return (
+    char === "," || char === "." || char === "<" || char === ">" || char === "/" || char === "?" || char === ";" || char === ":" || char === "'" || char === `"` || char === "[" || char === "{" || char === "]" || char === "}" || char === "!" || char === "@" || char === "#" || char === "$" || char === "%" || char === "^" || char === "*" || char === "(" || char === ")" || char === "-" || char === "_" || char === "=" || char === "+" || char === "\\" || char === "|" || char === "`" || char === "~" || // English symbol
+    char === "、" || char === "。" || char === "＜" || char === "＞" || char === "・" || char === "？" || char === "；" || char === "：" || char === "’" || char === "”" || char === "「" || char === "『" || char === "」" || char === "』" || char === "！" || char === "＠" || char === "＃" || char === "＄" || char === "％" || char === "＾" || char === "＊" || char === "（" || char === "）" || char === "ー" || char === "＿" || char === "＝" || char === "＋" || char === "￥" || char === "｜" || char === "｀" || char === "〜" // Japanese symbol
+  ) ? true : false
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extName__",
   "description": "__MSG_extDescription__",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "default_locale": "en",
   "icons": {
     "128": "icons/icon128.png"

--- a/test/test.js
+++ b/test/test.js
@@ -14,7 +14,7 @@ The developer of Character Counter.
     const [characters, spaces, words] = calculateCharacterCount(text)
     expect(characters).to.equal(51)
     expect(spaces).to.equal(6)
-    expect(words).to.equal(11)
+    expect(words).to.equal(8)
   });
   
   it('successfully count English with emoji', () => {
@@ -25,7 +25,7 @@ The developer of Character Counter.😎
     const [characters, spaces, words] = calculateCharacterCount(text)
     expect(characters).to.equal(53)
     expect(spaces).to.equal(6)
-    expect(words).to.equal(13)
+    expect(words).to.equal(10)
   });
 
   it('successfully count Japanese', () => {
@@ -36,7 +36,7 @@ Character Counter の開発者です。
     const [characters, spaces, words] = calculateCharacterCount(text)
     expect(characters).to.equal(42)
     expect(spaces).to.equal(4)
-    expect(words).to.equal(11)
+    expect(words).to.equal(9)
   });
   
   it('successfully count Japanese with emoji', () => {
@@ -47,7 +47,7 @@ Character Counter の開発者です。😎
     const [characters, spaces, words] = calculateCharacterCount(text)
     expect(characters).to.equal(44)
     expect(spaces).to.equal(4)
-    expect(words).to.equal(13)
+    expect(words).to.equal(11)
   });
 
   it('successfully count Japanese with surrogate pair', () => {


### PR DESCRIPTION
Symbols are not ignored for words.
<img width="1402" alt="screen shot of this bug" src="https://user-images.githubusercontent.com/51479912/178423231-1da1dd10-16d9-4482-9d8b-8aaa17ee59ea.png">
