### PR TITLE
Feat ignore symbols for words

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Click [here](https://github.com/H0R15H0/character_counter/blob/main/docs/README.
 <img src="https://user-images.githubusercontent.com/51479912/177196562-f7e84dbb-adf8-4ce4-a248-8747ab706054.png" alt="Character Counter Icon" style="justify-content: center;">
 </div>
 
-<img width="1024" alt="screen shot of Character Counter" src="https://user-images.githubusercontent.com/51479912/178274042-261e967b-a7b1-434c-8c2c-79eb27a77bc1.png">
+<img width="734" alt="en-image" src="https://user-images.githubusercontent.com/51479912/178424499-bea70a81-dc46-426d-a92f-99d84efb72bd.png">
 
 Chrome extension for count characters.
 Surrogate pair characters (e.g., emoji) can also be counted accurately.

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -5,7 +5,7 @@
 
 <img width="1024" alt="en-image" src="https://user-images.githubusercontent.com/51479912/178274042-261e967b-a7b1-434c-8c2c-79eb27a77bc1.png">
 
-<img width="640" alt="ja-image" src="https://user-images.githubusercontent.com/51479912/178418052-427787fa-d6c5-4277-9563-3fdf3755cd7d.png">
+<img width="709" alt="ja-image" src="https://user-images.githubusercontent.com/51479912/178423958-94feb1b3-a52b-41ed-8139-ba4c5f6bc1bd.png">
 
 文字数を数えてくれる Chrome Extension です。
 絵文字や日本語の「𪗱」「𪘚」といったサロゲートペアとなる文字まで正確に数えることができます。

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -3,7 +3,7 @@
 <img src="https://user-images.githubusercontent.com/51479912/177196562-f7e84dbb-adf8-4ce4-a248-8747ab706054.png" alt="文字数カウンター Icon" style="justify-content: center;">
 </div>
 
-<img width="1024" alt="en-image" src="https://user-images.githubusercontent.com/51479912/178274042-261e967b-a7b1-434c-8c2c-79eb27a77bc1.png">
+<img width="734" alt="en-image" src="https://user-images.githubusercontent.com/51479912/178424499-bea70a81-dc46-426d-a92f-99d84efb72bd.png">
 
 <img width="709" alt="ja-image" src="https://user-images.githubusercontent.com/51479912/178423958-94feb1b3-a52b-41ed-8139-ba4c5f6bc1bd.png">
 

--- a/src/count.js
+++ b/src/count.js
@@ -8,7 +8,7 @@ function calculateCharacterCount(string) {
 
   const characters = segmentsGrapheme.filter(char => !isNewLine(char.segment))
   const spaces = characters.filter(char => isSpace(char.segment))
-  const words = segmentsWord.filter(word => !isSpace(word.segment) && !isNewLine(word.segment))
+  const words = segmentsWord.filter(word => !isSpace(word.segment) && !isNewLine(word.segment) && !isSymbol(word.segment))
 
   return [characters.length, spaces.length, words.length]
 }
@@ -19,4 +19,11 @@ function isSpace(char) {
 
 function isNewLine(char) {
   return char === "\n" ? true : false
+}
+
+function isSymbol(char) {
+  return (
+    char === "," || char === "." || char === "<" || char === ">" || char === "/" || char === "?" || char === ";" || char === ":" || char === "'" || char === `"` || char === "[" || char === "{" || char === "]" || char === "}" || char === "!" || char === "@" || char === "#" || char === "$" || char === "%" || char === "^" || char === "*" || char === "(" || char === ")" || char === "-" || char === "_" || char === "=" || char === "+" || char === "\\" || char === "|" || char === "`" || char === "~" || // English symbol
+    char === "、" || char === "。" || char === "＜" || char === "＞" || char === "・" || char === "？" || char === "；" || char === "：" || char === "’" || char === "”" || char === "「" || char === "『" || char === "」" || char === "』" || char === "！" || char === "＠" || char === "＃" || char === "＄" || char === "％" || char === "＾" || char === "＊" || char === "（" || char === "）" || char === "ー" || char === "＿" || char === "＝" || char === "＋" || char === "￥" || char === "｜" || char === "｀" || char === "〜" // Japanese symbol
+  ) ? true : false
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extName__",
   "description": "__MSG_extDescription__",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "default_locale": "en",
   "icons": {
     "128": "icons/icon128.png"

--- a/test/test.js
+++ b/test/test.js
@@ -14,7 +14,7 @@ The developer of Character Counter.
     const [characters, spaces, words] = calculateCharacterCount(text)
     expect(characters).to.equal(51)
     expect(spaces).to.equal(6)
-    expect(words).to.equal(11)
+    expect(words).to.equal(8)
   });
   
   it('successfully count English with emoji', () => {
@@ -25,7 +25,7 @@ The developer of Character Counter.😎
     const [characters, spaces, words] = calculateCharacterCount(text)
     expect(characters).to.equal(53)
     expect(spaces).to.equal(6)
-    expect(words).to.equal(13)
+    expect(words).to.equal(10)
   });
 
   it('successfully count Japanese', () => {
@@ -36,7 +36,7 @@ Character Counter の開発者です。
     const [characters, spaces, words] = calculateCharacterCount(text)
     expect(characters).to.equal(42)
     expect(spaces).to.equal(4)
-    expect(words).to.equal(11)
+    expect(words).to.equal(9)
   });
   
   it('successfully count Japanese with emoji', () => {
@@ -47,7 +47,7 @@ Character Counter の開発者です。😎
     const [characters, spaces, words] = calculateCharacterCount(text)
     expect(characters).to.equal(44)
     expect(spaces).to.equal(4)
-    expect(words).to.equal(13)
+    expect(words).to.equal(11)
   });
 
   it('successfully count Japanese with surrogate pair', () => {


### PR DESCRIPTION
Symbols are not ignored for words.
Screen shot of bug.
<img width="1024" alt="screen shot of bug" src="https://user-images.githubusercontent.com/51479912/178274042-261e967b-a7b1-434c-8c2c-79eb27a77bc1.png">

If this PR merged
<img width="734" alt="en-image" src="https://user-images.githubusercontent.com/51479912/178424499-bea70a81-dc46-426d-a92f-99d84efb72bd.png">